### PR TITLE
master.keyをAWSのshared/configから読み込むように設定を追加

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,6 +11,9 @@ set :repo_url,  'git@github.com:gnfreeworks/mokucchi.git'
 # バージョンが変わっても共通で参照するディレクトリを指定
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 
+# 共通で参照するmaster.keyの場所を指定
+set :linked_files, fetch(:linked_files, []).push("config/master.key")
+
 set :rbenv_type, :user
 set :rbenv_ruby, '2.6.6' #カリキュラム通りに進めた場合、2.5.1か2.3.1です
 


### PR DESCRIPTION
master.keyをAWSのshared/configから読み込むように設定を追加しました。