### PR TITLE
Basic認証を廃止することにしたため修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,12 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :basic_auth
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :image])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :upload_image])
-  end
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
   end
 
 end


### PR DESCRIPTION
Basic認証を導入したが、採用担当者の手間を増やすことになると思い廃止。