### PR TITLE
トップページのVideoが動かない場合があるためmuted属性を追加

### DIFF
--- a/app/views/posts/_toppage.html.haml
+++ b/app/views/posts/_toppage.html.haml
@@ -1,5 +1,5 @@
 .wrap
-  = video_tag "top_movie.mp4", poster:"top_image.jpg",autoplay: true, loop: true, id:"bg-video"
+  = video_tag "top_movie.mp4", poster:"top_image.jpg",autoplay: true, loop: true, muted: true, id:"bg-video"
   .header-title
   
   .container-fluid


### PR DESCRIPTION
トップページのVideoが動かず更新すると動くなど不安定な場合があるためmuted属性を追加